### PR TITLE
remove baseurl variable from config

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -11,7 +11,6 @@ email: no-reply@usds.gov
 description: > # this means to ignore newlines until "baseurl:"
   The United States Digital Service is transforming how the federal government
   works for the American people. And we need you.
-baseurl: "./" # the subpath of your site, e.g. /blog
 url: "https://www.usds.gov" # the base hostname & protocol for your site
 twitter_username: usds
 github_username:  usds


### PR DESCRIPTION
setting the baseurl variable like this breaks the localhost development for me (all of the assets go to 404). removing the declaration entirely works. Would this change break prod for some reason?
