### PR TITLE
infographic line height change

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -643,7 +643,9 @@ body {
 .infographic-font-main {
   font-family: $header-font-family;
   font-size: 18px;
-  line-height: 30px;
+  p {
+    line-height: 30px;
+  }
 }
 
 .left-align{


### PR DESCRIPTION
The line-height CSS for the infrographic was getting over ridden by the main style sheet, so the directive of 30px line height wasn't being used.

This partially addresses #66 though it's not quite as much height as @mollieru asked for. IMO going that big in line height is too much, at least as it applies to all the `<p>`s. Specifically i think it makes the blue callout text line heights too big.
