### PR TITLE
Remove clickable img when nav logo collapses

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -22,7 +22,6 @@
         </li>
         <li class="nav-centerpiece">
           <a id="logo-desktop-full" href="/">
-            <img alt="The logo of the United States Digital Service" src="/img/layout/logo-desktop-full.png" />
           </a>
           <a id="logo-desktop-collapsed" href="/">
             <img alt="The logo of the United States Digital Service" src="/img/layout/logo-collapsed.png" />

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -21,7 +21,7 @@
           <a href="/work" class="{% if page.url == '/work.html' %}active{% endif %}"><span>Our work</span></a>
         </li>
         <li class="nav-centerpiece">
-          <a id="logo-desktop-full" href="/">
+          <a id="logo-desktop-full" href="/" title="The logo of the United States Digital Service">
           </a>
           <a id="logo-desktop-collapsed" href="/">
             <img alt="The logo of the United States Digital Service" src="/img/layout/logo-collapsed.png" />

--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -97,6 +97,10 @@ body {
           width: 250px;
           a#logo-desktop-full {
             top: -23px;
+            width: 250px;
+            height: 205px;
+            background: url('../img/layout/logo-desktop-full.png') center center no-repeat;
+            background-size: 205px 205px;
             img {
               width: 205px;
               bottom: 0;
@@ -123,8 +127,10 @@ body {
             }
             .nav-centerpiece {
               a#logo-desktop-full {
+                height: $fixed-header-height-desktop-collapsed - 32px;
                 @include opacity(0);
                 @include css3-prefix('transition', 'opacity 200ms linear');
+                @include css3-prefix('transition', 'height 0ms linear 201ms');
               }
               a#logo-desktop-collapsed {
                 @include opacity(1.00);


### PR DESCRIPTION
This fixes #116 

It uses a background image in the <a> link instead of an img, so that the height of the div can be transitioned to be smaller (matching the size of the collapsed nav bar). A CSS transition delays this heigh resize until after the opacity transition is complete.
