### PR TITLE
implment style fixes from #87

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -12,6 +12,7 @@ body {
   }
   h2, h3, h4 {
     font-weight: 700;
+    color: #205493;
   }
   @media (min-width: $screen-sm-min) {
     h1 {
@@ -280,6 +281,7 @@ body {
       position: relative;
       h1, h2 {
         display: block;
+        color: #fff;
       }
       h1 {
         margin-bottom: 0;
@@ -532,9 +534,11 @@ body {
     h4 {
       font-family: $base-font-family;
       font-weight: 300;
+      color: #fff;
     }
     h3 {
       font-size: 1.8em;
+      color: #fff;
     }
   } // .feature-panel
   .join-button {
@@ -545,7 +549,7 @@ body {
     color: #000;
     font-size: 1.3em;
     &:hover {
-      background-color: $background-color-secondary;
+      background-color: #CAB41F;
     }
   } // .join-button  
   
@@ -557,15 +561,18 @@ body {
       width: 165px;
       height: 120px;
       margin-right: 1em;
+      margin-left: 2em;
+      margin-bottom: 1em;
     }
     .eop-logo {
       max-height: 100px;
+      height: 120px;
     }
     .usds-logo {
       position: relative;
       bottom: 10px;
-      width: 103px;
-      height: 103px;
+      width: 140px;
+      height: 140px;
     }
     h4 {
       margin-top: 0;
@@ -584,6 +591,20 @@ body {
         &:before, &:after {
           content: none;
         }
+      }
+    }
+    .contribute-button {
+      height: 40px;
+      width: auto;
+      background-color: #fff;
+      border: 2px solid #0071BB;
+      color: #0071BB;
+      margin: 40px 0px;
+      
+      &:hover {
+        background: #fff;
+        color: #205593; 
+        border: 2px solid #205593;
       }
     }
   } // </footer>


### PR DESCRIPTION
This replaces #87, minus the merge conflicts.

It fixes #59, #15, #62, and #67  

It uses some of @mollieru's work as referenced here:
- Updates h1, h2, h3, h4 color to `#205493` in response to https://github.com/usds/website-redesign/issues/59 // https://github.com/usds/website-redesign/pull/87/commits/79569acfec4aebec656587aed572482081df53cd
- fixes to footer styling in response to https://github.com/usds/website-redesign/issues/15 // https://github.com/usds/website-redesign/pull/87/commits/6d321a9bbcd2f36273065867dcd47f3f8408b389
- button style tweaks in response to https://github.com/usds/website-redesign/issues/62 // https://github.com/usds/website-redesign/pull/87/commits/4961969d295b1c71e2682c20268a8025cdd793b3
- adds hover color to join button in response to https://github.com/usds/website-redesign/issues/65 // https://github.com/usds/website-redesign/pull/87/commits/2bca38f97174abcf2487e4a636aa6c1b935c75d5
