### PR TITLE
Rely on a few official Jekyll plugins

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,5 +1,6 @@
 ---
 layout: default
+sitemap: false
 ---
 
 <div class="usa-grid">

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,8 @@ collections:
 gems:
   - jekyll-seo-tag
   - jekyll-sitemap
-
+  - jekyll-redirect-from
+  
 # Jekyll SEO Tag
 # See https://github.com/jekyll/jekyll-seo-tag
 twitter:

--- a/_config.yml
+++ b/_config.yml
@@ -8,10 +8,9 @@
 # Site settings
 title: United States Digital Service
 email: no-reply@usds.gov
-description: > # this means to ignore newlines until "baseurl:"
+description: >
   The United States Digital Service is transforming how the federal government
   works for the American people. And we need you.
-baseurl: "/" # the subpath of your site, e.g. /blog
 url: "https://www.usds.gov" # the base hostname & protocol for your site
 twitter_username: usds
 github_username:  usds
@@ -23,3 +22,13 @@ markdown: kramdown
 collections:
   - project_summaries
   - blog_summaries
+
+gems:
+  - jekyll-seo-tag
+  - jekyll-sitemap
+
+# Jekyll SEO Tag
+# See https://github.com/jekyll/jekyll-seo-tag
+twitter:
+  username: usds
+logo: /img/usds-logo-onwhite.png

--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,19 +3,15 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-    <title>{% if page.title %}{{ page.title | escape }}{% else %}{{ site.title | escape }}{% endif %}</title>
-    <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
-    <meta property="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+    {% seo %}
 
-    <base href="{{ site.baseurl }}" />
     <link rel="shortcut icon" type="image/ico" href="/img/layout/favicon.ico" />
     <link rel="icon" type="image/png" href="/img/layout/favicon.png" />
 
     <link rel="stylesheet" href="/css/uswds.min.css" type="text/css" />
     <link rel="stylesheet" href="/css/font-awesome.min.css" type="text/css" />
     <link rel="stylesheet" href="/css/main.css">
-    <link rel="canonical" href="{{ page.url | replace:'index.html','' | prepend: site.baseurl | prepend: site.url }}">
-    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.baseurl | prepend: site.url }}">
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">
 
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,700' rel='stylesheet' type='text/css'>
     <script src="/js/jquery-1.12.3.min.js"></script>

--- a/index.html
+++ b/index.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 title: U.S. Digital Service
+redirect_from: /participate/united-states-digital-service.html
 ---
 
 
@@ -75,7 +76,7 @@ title: U.S. Digital Service
   </div>
 
   {% include projects.html num_columns=3 num_projects=3 %}
-  
+
   <div class="usa-grid">
     <div class="usa-width-one-whole">
       <a href="/work">

--- a/index.html
+++ b/index.html
@@ -1,6 +1,5 @@
 ---
 layout: default
-title: U.S. Digital Service
 redirect_from: /participate/united-states-digital-service.html
 ---
 

--- a/participate/united-states-digital-service.html
+++ b/participate/united-states-digital-service.html
@@ -1,4 +1,0 @@
----
-layout: minimal
----
-<META http-equiv="refresh" content="0;URL=/">


### PR DESCRIPTION
This pull request updates the site to use some of Jekyll's official plugins, mainly [Jekyll's official SEO plugin](https://github.com/jekyll/jekyll-seo-tag).
### Before

``` html
    <title>U.S. Digital Service</title>
    <meta name="description" content="The United States Digital Service is transforming how the federal government works for the American people. And we need you.
">
    <meta property="og:description" content="The United States Digital Service is transforming how the federal government works for the American people. And we need you.
">
```
### After

``` html
    <!-- Begin Jekyll SEO tag v1.4.0 -->
<title>United States Digital Service - The United States Digital Service is transforming how the federal government works for the American people. And we need you.</title>
<meta property="og:title" content="United States Digital Service" />
<meta name="description" content="The United States Digital Service is transforming how the federal government works for the American people. And we need you." />
<meta property="og:description" content="The United States Digital Service is transforming how the federal government works for the American people. And we need you." />
<link rel="canonical" href="https://www.usds.gov/" />
<meta property="og:url" content="https://www.usds.gov/" />
<meta property="og:site_name" content="United States Digital Service" />
<meta name="twitter:card" content="summary" />
<meta name="twitter:site" content="@usds" />
<script type="application/ld+json">
  {
    "@context": "http://schema.org",
    "@type": "WebSite",
    "name": "United States Digital Service",
    "headline": "United States Digital Service",
    "description": "The United States Digital Service is transforming how the federal government works for the American people. And we need you.",
    "logo": "https://www.usds.gov/img/usds-logo-onwhite.png",
    "url": "https://www.usds.gov/"
  }
</script>
<!-- End Jekyll SEO tag -->
```

The advantages to this approach are:
- Twitter and Facebook open graph data for richer social sharing
- JSON-LD markup for richer indexing
- Add USDS to the page title of each page for better SEO juice
- Add canonical URL

A few things to note:
- `baseurl` [should never be `/`](http://ben.balter.com/jekyll-style-guide/config/#baseurl). This is currently resulting in things like `"https://www.usds.gov//feed.xml"` on the live site.
- Both now and after this PR all pages will have the same description. The site would benefit from adding a human-generated `description` field to the top of each page.
- As pat of this PR, I added [Jekyll Redirect from](https://github.com/jekyll/jekyll-redirect-from) to redirect to the index from `/participate/united-states-digital-service.html`
- I also added [Jekyll Sitemap](https://github.com/jekyll/jekyll-sitemap) which will create a standards-based sitemap at `/sitemap.xml` without any action required on your part.
