### PR TITLE
Update setup instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,10 +10,10 @@ The site is built on the [U.S. Web Design Standards](https://playbook.cio.gov/de
 Setup
 ---
 1. If you're using a Mac, install homebrew (see http://brew.sh/)
-2. After installing git (`brew install git`), `cd` to the directory where you want to check-out the site, and then clone it (`git clone https://github.com/usds/website-redesign.git`)
+2. After installing git (`brew install git`), `cd` to the directory where you want to check-out the site, and then clone it (`git clone https://github.com/usds/website.git`)
 3. Install rvm (`\curl -sSL https://get.rvm.io | sudo bash -s stable`), make your current user a member of the rvm group, and then install a new version of ruby (`rvm install 2.3.1`)
-4. Install jekyll (`gem install jekyll`)
-  
+4. Install the `bundler` gem, then use bundler to install other project dependencies (`gem install bundler && bundle install`)
+
 Running
 ---
 1. In the directory you checked out the website into, run `jekyll serve` to start the webserver


### PR DESCRIPTION
Updates the setup instructions to 
- reference the latest repo name of `website` rather than `website-redesign`
- not assume that the `bundler` gem is already installed.
