### PR TITLE
Manually cache-bust CSS file

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -10,7 +10,7 @@
 
     <link rel="stylesheet" href="/css/uswds.min.css" type="text/css" />
     <link rel="stylesheet" href="/css/font-awesome.min.css" type="text/css" />
-    <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="/css/main.css?1">
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">
 
     <link href='https://fonts.googleapis.com/css?family=Open+Sans:300,400,700' rel='stylesheet' type='text/css'>


### PR DESCRIPTION
I'm sure there are better ways to do this with Jekyll, but most of the stuff I'm seeing on the internet suggests busting CSS every time you rebuild the site, and that's not very performant for users. Doing this quickly to fix some issues after #235, #233.