### PR TITLE
add the dots

### DIFF
--- a/_sass/_main.scss
+++ b/_sass/_main.scss
@@ -581,6 +581,7 @@ body {
     max-width: 100%;
     overflow: hidden;
     #staff-member-carousel {
+      padding-bottom: 25px;
       margin-top: 5rem;
     }
     .staffer {
@@ -609,6 +610,26 @@ body {
     //HACK: see https://github.com/18F/web-design-standards/issues/1120
     .staffer[aria-hidden=true]{
       display: block !important;
+    }
+
+    .slick-dots {
+      bottom: 0;
+      left: 0;
+
+      li {
+        display: inline-block !important;
+        width: 15px;
+
+        &:before,
+        &:after {
+          content: none;
+          display: none;
+        }
+
+        button:before {
+          font-size: 20px;
+        }
+      }
     }
   } // </section.staff-members>
 

--- a/js/script.js
+++ b/js/script.js
@@ -49,7 +49,7 @@ $( document ).ready(function() {
         headerCollapsed = false;
       }
     });
-    
+
     //
     // Show a full-screen width background behind the second level navigation
     // If anyone has a better idea how to do this cleaner/using only CSS, ideas
@@ -74,7 +74,7 @@ $( document ).ready(function() {
         subMenuBackground.hide();
       }
     })
-    
+
     //
     // Support for mobile hamburger nav
     //
@@ -88,9 +88,9 @@ $( document ).ready(function() {
         $(this).addClass('collapsed');
         $('.mobile-nav').addClass('collapsed');
       }
-      
+
     });
-    
+
     //
     // Handle all section show/hide behavior on join page
     //
@@ -128,14 +128,14 @@ $( document ).ready(function() {
       var hash = window.location.hash.substr(1);
       swapAnswer(hash);
     }
-    
+
     $('.join-page .faqs a').on('click', function(event) {
       event.stopPropagation(); // prevent bubbling
 
       var hash = this.hash.substr(1);
       swapAnswer(hash);
     });
-    
+
     //
     // Catch all outgoing liks that are not to .gov, .mil, facebook.com, github.com, or twitter.com
     // and display a "you are now leaving..." message
@@ -168,8 +168,8 @@ $( document ).ready(function() {
       $( '#site-alert-overlay' ).hide();
       $( '#site-alert' ).hide();
     });
-    
-    
+
+
     $('.everything-is-awesome').on( "click", function() {
       // Yes, there were more important things to get done, but everyone needs a mental break sometimes
       if (awesomeCounter >= 10) {
@@ -179,6 +179,6 @@ $( document ).ready(function() {
       // Not yet awesome
       awesomeCounter++;
     });
-    
-    
+
+
 });


### PR DESCRIPTION
For this issue #55 

Dots were definitely in the markup and set to `true` in the slick carousel script. Appears the main issue was that the USWDS was hiding visually any item that is hidden from screen readers, so it wasn't playing nice with anything outside of that paradigm. 

I've added a few styles to adjust spacing for the number of slides we are using. Here are some screen shots. 

<img width="1148" alt="screen shot 2017-03-22 at 11 50 17 am" src="https://cloud.githubusercontent.com/assets/25435289/24206837/d1df4d28-0ef5-11e7-95dd-e5f500bfcb50.png">

<img width="389" alt="screen shot 2017-03-22 at 11 50 28 am" src="https://cloud.githubusercontent.com/assets/25435289/24206844/d697608a-0ef5-11e7-9459-4f7ab823e93b.png">

@davidchang-gov, can you let me know if I can merge this or if it needs to go any other sort of review process?



