### PR TITLE
remove men/women breakdown

### DIFF
--- a/story.html
+++ b/story.html
@@ -77,19 +77,12 @@ title: About Us
     We&#8217;re proud of the products we&#8217;ve built. But we&#8217;re equally proud of the team we&#8217;ve assembled.
   </p>
 
-
-<div class="infographic-container infographic-font-main">
   <div class="row">
-      <div class="usa-width-one-half"><img src="/img/about/infographic/infographic-states.png" alt="united states" />Relocated from twelve states and Puerto Rico</div>
-      <div class="usa-width-one-half"><img src="/img/about/infographic/infographic-200.png" alt="200 text large" /><p>200+ people across agencies</p></div>
+    <div class="usa-width-one-third"><img src="/img/about/infographic/infographic-states.png" alt="united states" />Relocated from twelve states and Puerto Rico</div>
+    <div class="usa-width-one-third"><img src="/img/about/infographic/infographic-200.png" alt="200 text large" /><p>200+ people across agencies</p></div>
+    <div class="usa-width-one-third"><img src="/img/about/infographic/infographic-lamp.png" alt="laptop with stickers and emojis" /><p>Emoji, post-it, and sticker enthusiasts</p></div>
   </div>
-
-  <div class="row">
-      <div class="usa-width-one-half"><img src="/img/about/infographic/infographic-5050.png" alt="pie chart" /><p>Half women / Half men</p></div>
-      <div class="usa-width-one-half"><img src="/img/about/infographic/infographic-lamp.png" alt="laptop with stickers and emojis" /><p>Emoji, post-it, and sticker enthusiasts</p></div>
-  </div>
-</div>
-
+  
 </div>
 
   <!-- end infographic -->


### PR DESCRIPTION
This will remove the men/women breakdown graphic as noted in this issue. https://github.com/usds/website/issues/308

The I've modified the lockup to go from 2 rows of 2 graphics to a single row of three. 
<img width="909" alt="screen shot 2017-05-22 at 2 18 46 pm" src="https://cloud.githubusercontent.com/assets/25435289/26322666/fc4b3372-3ef9-11e7-87b0-167b05070e3e.png">
