### PR TITLE
Add `image` to the front matter for our Reports to Congress

### DIFF
--- a/_reports_to_congress/2016/01_letter.md
+++ b/_reports_to_congress/2016/01_letter.md
@@ -5,6 +5,7 @@ report: 2016
 report_title: December 2016
 permalink: /report-to-congress/2016/
 front: true
+image: /img/report-to-congress/capitol.jpg
 ---
 <div class="report-title">
   <p><img src="/img/report-to-congress/capitol.jpg" alt="Illustrated U.S. Capitol"></p>

--- a/_reports_to_congress/2017/07/01_letter.md
+++ b/_reports_to_congress/2017/07/01_letter.md
@@ -5,6 +5,7 @@ report: July 2017
 report_title: July 2017
 permalink: /report-to-congress/2017/07/
 front: true
+image: /img/report-to-congress/capitol.jpg
 ---
 <div class="report-title">
   <p><img src="/img/report-to-congress/capitol.jpg" alt="Illustrated U.S. Capitol"></p>


### PR DESCRIPTION
This will get picked up by jekyll-seo-tag. For some reason, social sites are picking up on Matt's signature for July 2017, even though they picked up on the Capitol illustration and not Mikey's signature for December 2016.