### PR TITLE
[Privacy] Anonymize IP address in Google Analytics

### DIFF
--- a/_includes/analytics.html
+++ b/_includes/analytics.html
@@ -6,6 +6,7 @@ if (!/^localhost/.test(location.host)) {
   })(window,document,'script','https://www.google-analytics.com/analytics.js','ga');
 
   ga('create', 'UA-76470670-2', 'auto', {'allowLinker': true});
+  ga('set', 'anonymizeIp', true);
   ga('send', 'pageview');
   ga('require', 'linker');
   ga('linker:autoLink', ['www.whitehouse.gov', 'www.usds.gov'] );


### PR DESCRIPTION
This change will request that Google mask the last octet of the IP address in memory before performing further processing.
https://support.google.com/analytics/answer/2763052?hl=en