### PR TITLE
remove trailing slash so FAQ link on how-we-work page works

### DIFF
--- a/_content/how_we_work.yml
+++ b/_content/how_we_work.yml
@@ -10,7 +10,7 @@ cops:
   heading_text: |-
      Our staff comes from all corners of the technology industry, nonprofit world, and government to serve ‘tours' of service, bringing a steady influx of fresh perspectives into government. Tours typically last between six months and two years, with a maximum length of four years.
 
-     Most of our staff have backgrounds in design, engineering, or product management. We also hire strategists, recruiters, procurement experts, attorneys, communications specialists and others, so if you don’t see yourself described below, you should still apply! For more info on USDS recruitment, [read our Hiring FAQ](../faq/).
+     Most of our staff have backgrounds in design, engineering, or product management. We also hire strategists, recruiters, procurement experts, attorneys, communications specialists and others, so if you don’t see yourself described below, you should still apply! For more info on USDS recruitment, [read our Hiring FAQ](../faq).
 
   #team_roles_heading: Team Roles
   #team_roles_text: |-


### PR DESCRIPTION
sidenote: shouldn't our links work with/without a trailing slash?