### PR TITLE
Use anonymize_ip

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -120,7 +120,7 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
    function gtag(){dataLayer.push(arguments);}
    gtag('js', new Date());
 
-   gtag('config', 'UA-132706295-1');
+   gtag('config', 'UA-132706295-1', { 'anonymize_ip': true });
   </script>
 
 </body>


### PR DESCRIPTION
See:
https://developers.google.com/analytics/devguides/collection/gtagjs/ip-anonymization

Replaces:
https://github.com/usds/website/pull/380

To better match our privacy docs:
https://www.usds.gov/privacy
> We have also limited the provider’s ability to see your full IP address (a process known as “IP masking”).