### PR TITLE
remove hover animation on cards for mobile devices

### DIFF
--- a/assets/stylesheets/components/_cards.scss
+++ b/assets/stylesheets/components/_cards.scss
@@ -25,10 +25,13 @@
 
 .site-c-card--linked:hover,
 .site-c-card--linked:focus  {
-  border: 1px solid $color-primary;
-  box-shadow: 0 2px 12px rgba(0,0,0,0.15);
   color: $color-gray;
-  transform: scaleX(1.02) scaleY(1.02);
+
+  @include at-media('tablet') {
+    border: 1px solid $color-primary;
+    box-shadow: 0 2px 12px rgba(0,0,0,0.15);
+    transform: scaleX(1.02) scaleY(1.02);
+  }
 }
 
 .site-c-card__body {


### PR DESCRIPTION
This PR removes the hover animation on linked cards that felt problematic on mobile devices. The animation is still present on tablet devices. 

More details in this issue: https://github.com/usds/website/issues/441