### PR TITLE
Fix link color

### DIFF
--- a/assets/stylesheets/base/_base.scss
+++ b/assets/stylesheets/base/_base.scss
@@ -78,6 +78,10 @@ hr {
   }
 }
 
+a {
+  color: $color-primary;
+}
+
 .usa-button svg {
   fill: white;
   display: inline-block;


### PR DESCRIPTION
Set link color to `$color-primary`, as described in https://github.com/usds/website/issues/457

Issue: 
There was no base link color set, so this was affecting all text links.