### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,8 @@
 
 ```
 $ npm install
-$ bundle exec jekyll serve
+$ bundle install
+$ npm run serve (or bundle exec jekyll serve)
 ```
 
 ### Updating USWDS to a later version.


### PR DESCRIPTION
Just a minor update to indicate that you may need to run bundle install. Also, you could type the shorter ```npm run serve```. We should make ```npm start``` run serve as start is the standard default command.