### PR TITLE
update labels for press kit

### DIFF
--- a/_content/news_and_blog.yml
+++ b/_content/news_and_blog.yml
@@ -22,4 +22,4 @@ for_the_press:
   email_button_text: "Email our press contact"
   email_link: mailto:USDSpress@omb.eop.gov
   press_kit_image: graphic-news-media-press-kit.svg
-  press_kit_button_text: "Download press kit"
+  press_kit_button_text: "Download press sheet"

--- a/_includes/_footer.html
+++ b/_includes/_footer.html
@@ -33,7 +33,7 @@
         <h2 class="site-c-footer__heading">Get in touch</h2>
         <ul class="site-c-footer__list tablet:padding-right-3">
           <li><a href="{{ site.baseurl }}{% link pages/contact-us.html %}">Contact us</a></li>
-          <li><a href="{{ site.baseurl }}/assets/files/{{ site.press_kit_file_name }}">USDS press kit</a></li>
+          <li><a href="{{ site.baseurl }}/assets/files/{{ site.press_kit_file_name }}">USDS press sheet</a></li>
         </ul>
       </div>
       <div class="grid-col-12 tablet:grid-col-4 desktop:grid-col margin-bottom-7">


### PR DESCRIPTION
Updates wording from "press kit" to "press sheet". (the remaining fixes for #516)

News & blog:
![Screen Shot 2020-06-07 at 10 44 13](https://user-images.githubusercontent.com/31673962/83971994-f1556180-a8ab-11ea-9cab-303a7852188c.png)

footer:
![Screen Shot 2020-06-07 at 10 43 32](https://user-images.githubusercontent.com/31673962/83971989-e8fd2680-a8ab-11ea-87bc-5896dc241d54.png)
