### PR TITLE
add CBS to news articles

### DIFF
--- a/_content/news_articles.yml
+++ b/_content/news_articles.yml
@@ -1,6 +1,6 @@
-- title: "Meet the Nerds Coding Their Way Through the Afghanistan War"
-  url: https://www.wired.com/2017/05/meet-nerds-coding-way-afghanistan-war/
-  source: WIRED
+- title: "This little-known program has played a central role in the U.S. government's coronavirus response"
+  url: https://www.cbsnews.com/news/coronavirus-us-digital-service-technology-government/
+  source: CBS News
 
 - title: "Feds come hunting tech talent in Silicon Valley"
   url: https://www.mercurynews.com/2018/06/01/feds-come-hunting-tech-talent-in-silicon-valley/


### PR DESCRIPTION
## summary of changes
replaces the WIRED piece with CBS This Morning. partial fix for #532.

### preview
Deployed to a [staging site](https://furyroad-chipper-squirrel-rl.app.cloud.gov).
Affects the homepage and "News & blog" page.

### blockers before deploying?
none