### PR TITLE
[/apply form] add event listener for height

### DIFF
--- a/pages/apply.html
+++ b/pages/apply.html
@@ -43,7 +43,7 @@ redirect_from:
 
   function resizeApplicationFrame(height){
     try{
-      frameResizedHeight = parseInt(height) + 25;
+      var frameResizedHeight = parseInt(height) + 25;
       if(isTestingMode){
         console.log(frameResizedHeight);
       } else{

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -28,11 +28,41 @@ redirect_from:
 
   <hr>
 
-  <iframe src="https://eop-fra.secure.force.com/digitalservice/" seamless width="100%" height="3600px" scrolling="no" frameBorder="0" title="Join USDS form"></iframe>
-
+  <iframe id='applicationFrame' src="https://eop-fra.secure.force.com/digitalservice/" seamless width="100%" height="3600px" scrolling="no" frameBorder="0" title="Join USDS form"></iframe>
   <section class="site-c-section">
     <div class="usa-prose">
       {{ content.eoe_statement | markdownify }}
     </div>
   </section>
 </div>
+
+<script>
+
+  var ifr = document.getElementById("applicationFrame");
+  var isTestingMode = true;
+
+  function resizeApplicationFrame(height){
+    try{
+      frameResizedHeight = parseInt(height) + 25;
+      if(isTestingMode){
+        console.log(frameResizedHeight);
+      } else{
+        ifr.style.height = frameResizedHeight + "px";
+      }
+    }
+    catch {
+    }
+  }
+  
+  window.addEventListener('message', function (e) {
+    var eventName = e.data[0];
+    var data      = e.data[1];
+
+    switch (eventName) {
+      case 'applicationFormHeight':
+        resizeApplicationFrame(data);
+        break;
+    }
+  }, false);
+
+</script>


### PR DESCRIPTION
## summary of changes
Adds a listener for the `applicationFormHeight` event (which we expect to be posted by the iframe source) and logs to console a proposed value for the iframe height. 

## next steps
Deploy this to an environment where the iframe loads. Verify that the proposed values (as logged to console) are reasonable for a variety of browser configurations. If that looks good, we could remove the `isTestingMode` logic. 

connects to: https://github.com/usds/website/issues/481