### PR TITLE
change stats sidebar header text

### DIFF
--- a/_includes/_template--project-page.html
+++ b/_includes/_template--project-page.html
@@ -8,7 +8,7 @@
   <div class="grid-row tablet:flex-row-reverse padding-top-3">
     <div class="tablet:grid-col-4 desktop:grid-col-3 margin-bottom-3 site-c-project-content">
       {% if page.impact_statement %}
-      <h2>The Impact</h2>
+      <h2>By the Numbers</h2>
       {% for item in page.impact_statement %}
         <div class="margin-bottom-3">
           <div>


### PR DESCRIPTION
Text for sidebar stats currently says "The Impact" which is odd now that some project profiles contain a "The Impact" section in the body. Propose changing to "By the numbers".