### PR TITLE
Add DAP js

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -47,4 +47,9 @@
     <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">
 
     {{ include.append }}
+
+    {% if jekyll.environment == 'production' %}
+      <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
+      <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=USDS" id="_fed_an_ua_tag"></script>
+    {% endif %}
 </head>

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -2,7 +2,7 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% if jekyll.environment == 'staging' %}
+    {% if jekyll.environment != 'production' %}
       <meta name="robots" content="noindex" />
     {% endif %}
 

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -2,9 +2,6 @@
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    {% if jekyll.environment != 'production' %}
-      <meta name="robots" content="noindex" />
-    {% endif %}
 
 {% capture url_path %}{{site.domain}}{{site.baseurl}}{{page.url}}{% endcapture %}
 
@@ -16,7 +13,7 @@
 
     <title>{{ page_title }}</title>
 
-    {% if page.hide_from_search %}
+    {% if page.hide_from_search or jekyll.environment !='production' %}
     <meta name="robots" content="noindex, nofollow" />
     {% endif %}
 
@@ -50,6 +47,6 @@
 
     {% if jekyll.environment == 'production' %}
       <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
-      <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=USDS" id="_fed_an_ua_tag"></script>
+      <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=EOP&amp;sub-agency=USDS" id="_fed_an_ua_tag"></script>
     {% endif %}
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -120,15 +120,17 @@ Meet Mollie the crab, our unofficial mascot :)
   <script src="{{ site.baseurl }}/assets/js/shims/svg4everybody.js"></script>
   <script>svg4everybody();</script>
 
-  <!-- Global site tag (gtag.js) - Google Analytics -->
-  <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132706295-1"></script>
-  <script>
-   window.dataLayer = window.dataLayer || [];
-   function gtag(){dataLayer.push(arguments);}
-   gtag('js', new Date());
+  {% if jekyll.environment == 'production' %}
+    <!-- Global site tag (gtag.js) - Google Analytics -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132706295-1"></script>
+    <script>
+     window.dataLayer = window.dataLayer || [];
+     function gtag(){dataLayer.push(arguments);}
+     gtag('js', new Date());
 
-   gtag('config', 'UA-132706295-1', { 'anonymize_ip': true });
-  </script>
+     gtag('config', 'UA-132706295-1', { 'anonymize_ip': true });
+    </script>
+  {% endif %}
 
 </body>
 

--- a/manifest.yml
+++ b/manifest.yml
@@ -5,3 +5,5 @@ applications:
   instances: 1
   buildpack: https://github.com/cloudfoundry/staticfile-buildpack
   random-route: true
+  env:
+    JEKYLL_ENV: staging


### PR DESCRIPTION
Fixes #620 

- [x] Adds DAP js to default template
- [x] Wraps DAP and GA codes with a production environment variable
- [ ] Builds gh-pages site with `JEKYLL_ENV=production bundle exec jekyll build`