### PR TITLE
adjust gtag.js placement

### DIFF
--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -48,5 +48,15 @@
     {% if jekyll.environment == 'production' %}
       <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
       <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=EOP&amp;sub-agency=USDS" id="_fed_an_ua_tag"></script>
+
+      <!-- Global site tag (gtag.js) - Google Analytics -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132706295-1"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'UA-132706295-1', { 'anonymize_ip': true });
+      </script>
     {% endif %}
+
 </head>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -120,18 +120,6 @@ Meet Mollie the crab, our unofficial mascot :)
   <script src="{{ site.baseurl }}/assets/js/shims/svg4everybody.js"></script>
   <script>svg4everybody();</script>
 
-  {% if jekyll.environment == 'production' %}
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-132706295-1"></script>
-    <script>
-     window.dataLayer = window.dataLayer || [];
-     function gtag(){dataLayer.push(arguments);}
-     gtag('js', new Date());
-
-     gtag('config', 'UA-132706295-1', { 'anonymize_ip': true });
-    </script>
-  {% endif %}
-
 </body>
 
 </html>


### PR DESCRIPTION
## summary of changes
Move the google analytics global site tag (gtag.js) to the `<head>`. 
why: recommendation from the gtag [developers guide](https://developers.google.com/analytics/devguides/collection/gtagjs#install_the_global_site_tag) 