### PR TITLE
Identify nonprod sites

### DIFF
--- a/_includes/_banner.html
+++ b/_includes/_banner.html
@@ -6,7 +6,11 @@
           <img class="usa-banner__header-flag" src="/assets/img/us_flag_small.png" alt="U.S. flag">
         </div>
         <div class="grid-col-fill tablet:grid-col-auto">
+          {% if jekyll.environment == "production" %}
           <p class="usa-banner__header-text">An official website of the United States government</p>
+         {% else %}
+          <p class="usa-banner__header-text">AN UNOFFICIAL DRAFT COPY OF an official website of the United States government</p>
+         {% endif %}
           <p class="usa-banner__header-action" aria-hidden="true">Here’s how you know</p>
         </div>
         <button class="usa-accordion__button usa-banner__button"


### PR DESCRIPTION
Per Slack discussion, this modifies the banner text for non-production environments to indicate that the site is not official.