### PR TITLE
wget sitemap

### DIFF
--- a/cypress/e2e/sitemap.sh
+++ b/cypress/e2e/sitemap.sh
@@ -2,12 +2,14 @@
 
 # It is currently impossible to dynamically generate Cypress tests based on data loaded asynchronously.
 # That's just what we want so that the visual tests do not have to be updated when we add new pages.
-# A common workaround is for the Cypress spec to `require` a JSON file containing the needed data.
+# A common workaround is to generate a JSON file of the needed data before Cypress is run.
+# The Cypress spec can `require` that JSON file and dynamically generate tests from its contents.
 # So, this script writes a JSON file containing all non-PDF URLs from sitemap.xml.
 # This script is executed by the package.json script that creates/updates base images.
 
 # A regex and sed expert could surely simplify this pipeline. Here's each step, in order.
-  # Extract local URLs from sitemap.xml
+  # Download sitemap.xml from the local host
+  # Extract local URLs 
   # Remove surrounding XML tags
   # Get rid of PDF URLs
   # Add surrounding quotation marks and trailing commas
@@ -15,7 +17,8 @@
   # Add opening brace
   # Add closing brace
 
-grep 'http:\/\/0' ../../_site/sitemap.xml | \
+wget -O - --quiet http://localhost:4080/sitemap.xml | \
+grep 'http:\/\/0' | \
 sed 's/<loc>http:\/\/0\.0\.0\.0:4000\/\(.*\)<\/loc>/\1/g' | \
 grep -v '\.pdf$' | \
 sed 's/\(.*\)/"\1",/' | \


### PR DESCRIPTION
While trying to solve Cypress workflow problems, the code was changed to read the sitemap from the local file system instead of downloading it from the locally running server.

I realized that this will not work for a dev who has worked exclusively in Docker and has no locally built `_site` folder. This changes back to downloading from the local server.
