### PR TITLE
Fix html headers

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,6 +1,7 @@
 ---
 layout: default
 simple_footer: true
+hide_from_search: true
 permalink: /404.html
 banner_file: banner--404-lg.svg
 banner_file_mobile: banner--404-sm.svg

--- a/_config.yml
+++ b/_config.yml
@@ -26,7 +26,7 @@ domain: "https://usds.gov"
 
 timezone: "America/New_York"
 social_image: social-card--default.png
-social_image_alt_text: "Blue graphic reads 'Building a better government for the people' with USDS logo: navy blue shield with three stars, two stripes and yellow wings"
+social_image_alt_text: "Graphic with bold text that reads 'Building a better government for the people.' Text is displayed next to the USDS logo, a navy blue shield with three stars, two stripes and yellow wings."
 
 twitter_username: usds
 

--- a/_config.yml
+++ b/_config.yml
@@ -26,6 +26,7 @@ domain: "https://usds.gov"
 
 timezone: "America/New_York"
 social_image: social-card--default.png
+social_image_alt_text: "Blue graphic reads 'Building a better government for the people' with USDS logo: navy blue shield with three stars, two stripes and yellow wings"
 
 twitter_username: usds
 

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -1,36 +1,85 @@
+{%- assign base_url = site.domain | append: site.baseurl -%}
+{%- assign full_page_url = base_url | append: page.url -%}
+
+{%- if page.people_page -%}
+{%-   assign page_title = page.name  | append: " | " | append: site.title -%}
+{%- elsif page.title -%}
+{%-   assign page_title = page.title | append: " | " | append: site.title -%}
+{%- else -%}
+{%-   assign page_title = site.title -%}
+{%- endif -%}
+
+{%- if page.people_page -%}
+{%-   assign share_image = base_url | append: "/images/"  | append: page.image_name -%}
+{%- elsif page.project_page -%}
+{%-   assign share_image = base_url | append: "/images/"  | append: page.carousel_image_name -%}
+{%- elsif page.social_image -%}
+{%-   assign share_image = base_url | append: "/assets/img/" | append: page.social_image -%}
+{%- elsif site.social_image -%}
+{%-   assign share_image = base_url | append: "/assets/img/" | append: site.social_image -%}
+{%- else -%}
+{%-   assign share_image = base_url | append: "/assets/img/social-card--default.png" -%}
+{%- endif -%}
+
+{%- if page.social_image -%}
+{%-   assign share_image_alt = page.social_image_alt_text -%}
+{%- elsif page.carousel_image_alt_text -%}
+{%-   assign share_image_alt = page.carousel_image_alt_text -%}
+{%- else -%}
+{%-   assign share_image_alt =  page.name -%}
+{%- endif -%}
+
+{%- if page.description -%}
+{%-   assign page_description = page.description -%}
+{%- else -%}
+{%-   assign page_description = page.content | newline_to_br | strip_newlines | replace: '<br />', ' ' | strip_html | strip | truncatewords: 30 -%}
+{%- endif -%}
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
     <meta name="viewport" content="width=device-width, initial-scale=1">
 
-{% capture url_path %}{{site.domain}}{{site.baseurl}}{{page.url}}{% endcapture %}
-
-{% capture page_title %}{% if page.people_page %}{{ page.name }} | {{ site.title }}{% elsif page.title %}{{ page.title }} | {{ site.title }}{% else %}{{ site.title }}{% endif %}{% endcapture %}
-
-{% capture share_image %}{% if page.people_page %}{{site.domain}}{{ site.baseurl }}/images/{{ page.image_name }}{% elsif page.project_page %}{{site.domain}}{{ site.baseurl }}/images/{{ page.carousel_image_name }}{% elsif page.social_image %}{{site.domain}}{{ site.baseurl }}/assets/img/{{ page.social_image }}{% else %}{{site.domain}}{{ site.baseurl }}/assets/img/{{ site.social_image }}{% endif %}{% endcapture %}
-
-{% capture page_description %}{% if page.description %}{{ page.description }}{% else %}{{ content | newline_to_br | strip_newlines | replace: '<br />', ' ' | strip_html | strip | truncatewords: 30 }}{% endif %}{% endcapture %}
-
     <title>{{ page_title }}</title>
 
-    {% if page.hide_from_search or jekyll.environment !='production' %}
+    {% if page.hide_from_search or jekyll.environment !='production' -%}
     <meta name="robots" content="noindex, nofollow" />
-    {% endif %}
+    {% else -%}
+    <meta name="robots" content="index" />
+    {% endif -%}
 
     <meta name="description" content="{{ page_description }}" />
-    <link rel="canonical" href="{{ url_path }}" />
+    <link rel="canonical" href="{{ full_page_url }}" />
     <meta property="og:title" content="{{ page_title }}" />
     <meta property="og:locale" content="en_US" />
     <meta property="og:description" content="{{ page_description }}" />
-    <meta property="og:url" content="{{ url_path }}" />
+    <meta property="og:url" content="{{ full_page_url }}" />
     <meta property="og:site_name" content="{{ site.title }}" />
     <meta property="og:type" content="article" />
     <meta property="og:image" content="{{ share_image }}">
+    <meta property="og:image:alt" content="{{ share_image_alt }}">
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@usds" />
     <meta name="twitter:image" content="{{ share_image }}">
-    <script type="application/ld+json">
-    {"description":"{{ page_description ","@type":"BlogPosting","url":"{{url_path }}","publisher":{"@type":"Organization","logo":{"@type":"ImageObject","url":"{{site.baseurl}}/img/usds-logo-onwhite.png"}},"headline":"{{ page_title }}","dateModified":"{{site.time}}","datePublished":"{{site.time}}","mainEntityOfPage":{"@type":"WebPage","@id":"{{url_path }}"},"@context":"http://schema.org"}</script>
+    <script type="application/ld+json">{
+        "description": "{{page_description}}",
+        "@type": "BlogPosting",
+        "url": "{{full_page_url}}",
+        "publisher": {
+            "@type": "Organization",
+            "logo": {
+                "@type": "ImageObject",
+                "url": "{{site.baseurl}}/img/usds-logo-onwhite.png"
+            }
+        },
+        "headline": "{{page_title}}",
+        "dateModified": "{{site.time}}",
+        "datePublished": "{{site.time}}",
+        "mainEntityOfPage": {
+            "@type": "WebPage",
+            "@id": "{{full_page_url}}"
+        },
+        "@context": "http://schema.org"
+    }</script>
 
     <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/img/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/img/favicons/favicon-32x32.png">
@@ -41,13 +90,11 @@
     <meta name="theme-color" content="#ffffff">
 
     <link rel="stylesheet" media="all" href="{{ site.baseurl }}/assets/stylesheets/styles.css"></link>
-    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ "/feed.xml" | prepend: site.url }}">
-
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | prepend: site.url }}"></link>
     {{ include.append }}
-
     <script type="application/javascript" src="{{ site.baseurl }}/assets/js/vendor/uswds-init.min.js"></script>
 
-    {% if jekyll.environment == 'production' %}
+    {% if jekyll.environment == 'production' -%}
       <!-- We participate in the US government's analytics program. See the data at analytics.usa.gov. -->
       <script async type="text/javascript" src="https://dap.digitalgov.gov/Universal-Federated-Analytics-Min.js?agency=EOP&amp;sub-agency=USDS" id="_fed_an_ua_tag"></script>
 
@@ -59,6 +106,5 @@
         gtag('js', new Date());
         gtag('config', 'UA-132706295-1', { 'anonymize_ip': true });
       </script>
-    {% endif %}
-
+    {% endif -%}
 </head>

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -9,6 +9,12 @@
 {%-   assign page_title = site.title -%}
 {%- endif -%}
 
+{%- if page.description -%}
+{%-   assign page_description = page.description -%}
+{%- else -%}
+{%-   assign page_description = content | newline_to_br | strip_newlines | replace: '<br />', ' ' | strip_html | strip | truncatewords: 30 -%}
+{%- endif -%}
+
 {%- if page.people_page -%}
 {%-   assign share_image = base_url | append: "/images/"  | append: page.image_name -%}
 {%- elsif page.project_page -%}
@@ -26,14 +32,9 @@
 {%- elsif page.carousel_image_alt_text -%}
 {%-   assign share_image_alt = page.carousel_image_alt_text -%}
 {%- else -%}
-{%-   assign share_image_alt =  page.name -%}
+{%-   assign share_image_alt =  page_description -%}
 {%- endif -%}
 
-{%- if page.description -%}
-{%-   assign page_description = page.description -%}
-{%- else -%}
-{%-   assign page_description = content | newline_to_br | strip_newlines | replace: '<br />', ' ' | strip_html | strip | truncatewords: 30 -%}
-{%- endif -%}
 <head>
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
@@ -60,7 +61,8 @@
     <meta name="twitter:card" content="summary_large_image" />
     <meta name="twitter:site" content="@usds" />
     <meta name="twitter:image" content="{{ share_image }}">
-    <script type="application/ld+json">{
+    <script type="application/ld+json">
+    {
         "description": "{{page_description}}",
         "@type": "BlogPosting",
         "url": "{{full_page_url}}",
@@ -79,7 +81,8 @@
             "@id": "{{full_page_url}}"
         },
         "@context": "http://schema.org"
-    }</script>
+    }
+    </script>
 
     <link rel="apple-touch-icon" sizes="180x180" href="{{ site.baseurl }}/assets/img/favicons/apple-touch-icon.png">
     <link rel="icon" type="image/png" sizes="32x32" href="{{ site.baseurl }}/assets/img/favicons/favicon-32x32.png">
@@ -89,8 +92,8 @@
     <meta name="msapplication-TileColor" content="#da532c">
     <meta name="theme-color" content="#ffffff">
 
-    <link rel="stylesheet" media="all" href="{{ site.baseurl }}/assets/stylesheets/styles.css"></link>
-    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | prepend: site.url }}"></link>
+    <link rel="stylesheet" media="all" href="{{ site.baseurl }}/assets/stylesheets/styles.css" />
+    <link rel="alternate" type="application/rss+xml" title="{{ site.title }}" href="{{ '/feed.xml' | prepend: site.url }}" />
     {{ include.append }}
     <script type="application/javascript" src="{{ site.baseurl }}/assets/js/vendor/uswds-init.min.js"></script>
 

--- a/_includes/_head.html
+++ b/_includes/_head.html
@@ -32,7 +32,7 @@
 {%- if page.description -%}
 {%-   assign page_description = page.description -%}
 {%- else -%}
-{%-   assign page_description = page.content | newline_to_br | strip_newlines | replace: '<br />', ' ' | strip_html | strip | truncatewords: 30 -%}
+{%-   assign page_description = content | newline_to_br | strip_newlines | replace: '<br />', ' ' | strip_html | strip | truncatewords: 30 -%}
 {%- endif -%}
 <head>
     <meta charset="utf-8" />

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -57,58 +57,58 @@ MMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMMM
 Meet Mollie the crab, our unofficial mascot :)
 -->
 
-{% include _head.html %}
+{%- include _head.html -%}
 
 <body>
 
-  <a class="usa-skipnav" href="#main-content">Skip to main content</a>
+<a class="usa-skipnav" href="#main-content">Skip to main content</a>
 
-  {% include _banner.html %}
+{%- include _banner.html -%}
 
-  {% include _header.html %}
+{%- include _header.html -%}
 
-  <main id="main-content" role="main">
- {% if page.banner_file %}
+<main id="main-content" role="main">
+  {%- if page.banner_file -%}
   <div class="site-c-page-banner">
     <img src="{{ site.baseurl }}/assets/img/{{ page.banner_file }}" srcset="{{ site.baseurl }}/assets/img/{{ page.banner_file_mobile }} 640w,
           {{ site.baseurl }}/assets/img/{{ page.banner_file }}" alt="">
   </div>
-  {% endif %}
-    {% if page.project_page %}
-      {% include _template--project-page.html %}
-    {% elsif page.people_page %}
-      {% include _template--people-page.html %}
-    {% elsif page.collection == 'reports_to_congress' %}
-      {% include _template--report-to-congress.html %}
-    {% elsif page.project_charter %}
-      {% include _template--charter.html %}
-    {% elsif page.blog_page %}
-      {% include _template--blog-post-page.html %}
-    {% elsif page.markdown_only %}
-      {% include _markdown-only.html %}
-    {% else %}
-    <div class="margin-bottom-9">
-      {{ content }}
-      </div>
-    {% endif %}
+  {%- endif -%}
+  {%- if page.project_page -%}
+  {%-   include _template--project-page.html -%}
+  {%- elsif page.people_page -%}
+  {%-   include _template--people-page.html -%}
+  {%- elsif page.collection == 'reports_to_congress' -%}
+  {%-   include _template--report-to-congress.html -%}
+  {%- elsif page.project_charter -%}
+  {%-   include _template--charter.html -%}
+  {%- elsif page.blog_page -%}
+  {%-   include _template--blog-post-page.html -%}
+  {%- elsif page.markdown_only -%}
+  {%-   include _markdown-only.html -%}
+  {%- else -%}
+  <div class="margin-bottom-9">
+    {{ content }}
+  </div>
+  {%- endif -%}
 
-      <section class="site-c-billboard">
-        <div class="grid-container">
-          <p>We need you.</p>
-          <p>Let’s help millions of people together.</p>
-          <p><a class="usa-button usa-button--outline usa-button--inverse" href="{{ site.baseurl }}/apply">Apply now</a></p>
-        </div>
-      </section>
+  <section class="site-c-billboard">
+    <div class="grid-container">
+      <p>We need you.</p>
+      <p>Let’s help millions of people together.</p>
+      <p><a class="usa-button usa-button--outline usa-button--inverse" href="{{ site.baseurl }}/apply">Apply now</a></p>
+    </div>
+  </section>
 
-  </main>
+</main>
 
-  {% include _footer.html %}
-  {% include _env-indicator.html %}
+{% include _footer.html %}
+{% include _env-indicator.html %}
 
-  <script src="{{ site.baseurl }}/assets/js/application.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>
-  <script src="{{ site.baseurl }}/assets/js/shims/svg4everybody.js"></script>
-  <script>svg4everybody();</script>
+<script src="{{ site.baseurl }}/assets/js/application.js"></script>
+<script src="{{ site.baseurl }}/assets/js/vendor/uswds.min.js"></script>
+<script src="{{ site.baseurl }}/assets/js/shims/svg4everybody.js"></script>
+<script>svg4everybody();</script>
 
 </body>
 

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -6,7 +6,7 @@ permalink: /apply
 banner_file: banner--join-us-lg.svg
 banner_file_mobile: banner--join-us-sm.svg
 social_image: social-card--join-us.png
-social_image_alt_text: "Blue graphic reads 'USDS needs you. Apply now' with USDS logo: navy blue shield with three stars, two stripes and yellow wings"
+social_image_alt_text: "Graphic with bold text that reads 'USDS needs you. Apply now.' Text is displayed under the USDS logo, a navy blue shield with three stars, two stripes and yellow wings."
 
 redirect_from:
   - /join

--- a/pages/apply.html
+++ b/pages/apply.html
@@ -6,6 +6,7 @@ permalink: /apply
 banner_file: banner--join-us-lg.svg
 banner_file_mobile: banner--join-us-sm.svg
 social_image: social-card--join-us.png
+social_image_alt_text: "Blue graphic reads 'USDS needs you. Apply now' with USDS logo: navy blue shield with three stars, two stripes and yellow wings"
 
 redirect_from:
   - /join

--- a/pages/contact-us.html
+++ b/pages/contact-us.html
@@ -5,6 +5,7 @@ banner_file: banner--contact-us-lg.svg
 banner_file_mobile: banner--contact-us-sm.svg
 permalink: /contact-us
 social_image: social-card--contact-us.png
+social_image_alt_text: "Navy blue graphic block with a blue satellite and yellow moon"
 ---
 
 <div class="grid-container">

--- a/pages/contact-us.html
+++ b/pages/contact-us.html
@@ -5,7 +5,7 @@ banner_file: banner--contact-us-lg.svg
 banner_file_mobile: banner--contact-us-sm.svg
 permalink: /contact-us
 social_image: social-card--contact-us.png
-social_image_alt_text: "Navy blue graphic block with a blue satellite and yellow moon"
+social_image_alt_text: "Graphic illustration of a large satellite dish listening for signals. A full moon hangs above the dish in a night time sky."
 ---
 
 <div class="grid-container">

--- a/pages/events.html
+++ b/pages/events.html
@@ -6,7 +6,7 @@ banner_file: banner--events-tour-map-lg.svg
 banner_file_mobile: banner--events-tour-map-sm.svg
 permalink: /events
 social_image: social-card--events.png
-social_image_alt_text: "Blue graphic reads 'Come meet us' with calendar graphics and USDS logo: navy blue shield with three stars, two stripes and yellow wings"
+social_image_alt_text: "Graphic with bold text that reads 'Come meet us.' Text is displayed next to an illustration of a calendar and above the USDS logo, a navy blue shield with three stars, two stripes and yellow wings."
 
 ---
 

--- a/pages/events.html
+++ b/pages/events.html
@@ -6,6 +6,8 @@ banner_file: banner--events-tour-map-lg.svg
 banner_file_mobile: banner--events-tour-map-sm.svg
 permalink: /events
 social_image: social-card--events.png
+social_image_alt_text: "Blue graphic reads 'Come meet us' with calendar graphics and USDS logo: navy blue shield with three stars, two stripes and yellow wings"
+
 ---
 
 {% assign content = site.data.events %}

--- a/pages/home.html
+++ b/pages/home.html
@@ -3,6 +3,7 @@ layout: default
 description: The United States Digital Service is transforming how the federal government works for the American people. And we need you.
 permalink: /
 social_image: social-card--homepage.jpg
+social_image_alt_text: "A dozen USDS staff members are seated, using laptops around a presentation white board that illustrates a workflow diagram."
 
 redirect_from:
   - /join-government

--- a/pages/home.html
+++ b/pages/home.html
@@ -3,7 +3,7 @@ layout: default
 description: The United States Digital Service is transforming how the federal government works for the American people. And we need you.
 permalink: /
 social_image: social-card--homepage.jpg
-social_image_alt_text: "A dozen USDS staff members are seated, using laptops around a presentation white board that illustrates a workflow diagram."
+social_image_alt_text: "A group of USDS staff members are seated on chairs and couches in the organization's headquarters. They are working on laptops and listening to a presentation from a colleague, who is pointing to a workflow diagram drawn on a white board."
 
 redirect_from:
   - /join-government

--- a/pages/how-we-work.html
+++ b/pages/how-we-work.html
@@ -5,6 +5,7 @@ banner_file: banner--how-we-work-lg.svg
 banner_file_mobile: banner--how-we-work-sm.svg
 permalink: /how-we-work
 social_image: social-card--how-we-work.png
+social_image_alt_text: "Navy blue graphic block with gray, blue and yellow squares illustrating sticky notes"
 
 redirect_from:
   - /work

--- a/pages/how-we-work.html
+++ b/pages/how-we-work.html
@@ -5,7 +5,7 @@ banner_file: banner--how-we-work-lg.svg
 banner_file_mobile: banner--how-we-work-sm.svg
 permalink: /how-we-work
 social_image: social-card--how-we-work.png
-social_image_alt_text: "Navy blue graphic block with gray, blue and yellow squares illustrating sticky notes"
+social_image_alt_text: "Graphic illustration of gray, blue and yellow colored sticky notes arranged in a grid. Some of the notes are blank, some have writing on them, and one has a dog-eared corner."
 
 redirect_from:
   - /work

--- a/pages/mission.html
+++ b/pages/mission.html
@@ -5,6 +5,7 @@ permalink: /mission
 banner_file: banner--our-mission-lg.svg
 banner_file_mobile: banner--our-mission-sm.svg
 social_image: social-card--our-mission.png
+social_image_alt_text: "Navy blue graphic block with a yellow star in the upper right corner"
 
 redirect_from:
   - /about

--- a/pages/mission.html
+++ b/pages/mission.html
@@ -5,7 +5,7 @@ permalink: /mission
 banner_file: banner--our-mission-lg.svg
 banner_file_mobile: banner--our-mission-sm.svg
 social_image: social-card--our-mission.png
-social_image_alt_text: "Navy blue graphic block with a yellow star in the upper right corner"
+social_image_alt_text: "Graphic illustration of a five-point, yellow star in the night sky. Blue and gray colored rays converge at a horizon line just under the star."
 
 redirect_from:
   - /about

--- a/pages/news-and-blog.html
+++ b/pages/news-and-blog.html
@@ -5,6 +5,7 @@ permalink: /news-and-blog
 banner_file: banner--news-media-lg.svg
 banner_file_mobile: banner--news-media-sm.svg
 social_image: social-card--news-and-media.png
+social_image_alt_text: "Navy blue graphic block with blue and yellow overlapping spotlight shapes"
 
 redirect_from:
   - /blog

--- a/pages/news-and-blog.html
+++ b/pages/news-and-blog.html
@@ -5,7 +5,7 @@ permalink: /news-and-blog
 banner_file: banner--news-media-lg.svg
 banner_file_mobile: banner--news-media-sm.svg
 social_image: social-card--news-and-media.png
-social_image_alt_text: "Navy blue graphic block with blue and yellow overlapping spotlight shapes"
+social_image_alt_text: "Graphic illustration of two spotlights projecting downward on a dark blue field. A bright yellow area is highlighted where the two spotlights overlap."
 
 redirect_from:
   - /blog


### PR DESCRIPTION
Changes:
- Added two headers that were reported as missing: `<meta name="robots" ` and `<meta property="og:image:alt" `
- `<meta name="robots" content="noindex, nofollow" />` was there for non-production and if the `page.hide_from_search` was set; however, the inverse of `<meta name="robots" content="index" />` wasn't there.
- `<meta property="og:image:alt"` is a 508 string. It's dynamic depending on the image being displayed. Pages will need to include a `social_image_alt_text` or `carousel_image_alt_text` with their custom images.
- Started using`{%-` and `-%}` which removes the blank line feeds from the output. When an eng candidate might look at our source, all the blank spaces look pretty sloppy. Also, hurting code readability to prevent extra whitespace in output is an anti-pattern.
- Move the 5x-step if/else logic out of a single line and into separate lines at the top of the file so it is readable.
- Repeated process for other variables to be consistent.
- Split out the `application/ld+json` json into multiple lines to be more readable. It is super confusing because `{{` could be json OR Jekyll syntax. Fixed at least one bug related to this confusion.
- 404 page was not set to be ignored


How I tested:
 1. On `main` branch, use the `build` or `build-staging` to generate the static html into `_site`
 2. Back up somewhere to make diff with changes easier or rename it to `_site_main`
 3. Switch to this branch and rebuild again.
 4. Compare outputted files focusing on html headers. (There should be no body content changes)
 
 
 