### PR TITLE
Initial support

### DIFF
--- a/_includes/_template--report-to-congress.html
+++ b/_includes/_template--report-to-congress.html
@@ -44,34 +44,52 @@
     <div class="tablet:grid-col-8 desktop:grid-col-9 margin-bottom-9 tablet:padding-right-4 site-c-report-to-congress">
       {{ content }}
 
+      {% if page.impact_statement %}
+      <hr aria-hidden="true">
+      <div class="grid-container">
+        <h2>By the Numbers</h2>
+        <div class="site-c-cards margin-x-neg-2 grid-row flex-wrap">
+          {% for item in page.impact_statement %}
+          <div class="padding-x-2 tablet:grid-col-6 desktop:grid-col-6 flex-align-stretch margin-bottom-3">
+            <div cass="site-c-card">
+              <span class="text-primary text-bold font-body-3xl">{{ item.figure }}</span><span
+                class="text-primary text-bold font-body-2xl">{{ item.unit}}</span>
+            </div>
+            <div>{{ item.description | replace: 'site.baseurl', site.baseurl | markdownify }}</div>
+          </div>
+          {% endfor %}
+        </div>
+      </div>
+    {% endif %}
+
       {% if page.previous_entry %}
-        {% assign previous_entry = site.reports_to_congress | where: "url", page.previous_entry | first %}
-        {% if previous_entry %}
-          <p>This project was previously chronicled in our <a href="{{ site.baseurl }}{{ previous_entry.url }}">{{ previous_entry.report }} Report to Congress</a>.</p>
-        {% endif %}
+      {% assign previous_entry = site.reports_to_congress | where: "url", page.previous_entry | first %}
+      {% if previous_entry %}
+      <p>This project was previously chronicled in our <a href="{{ site.baseurl }}{{ previous_entry.url }}">{{ previous_entry.report }} Report to Congress</a>.</p>
+      {% endif %}
       {% endif %}
     </div>
 
-    <div class="tablet:grid-col-4 desktop:grid-col-3 margin-bottom-3 site-c-report-to-congress side-nav">
-      <ul>
+  <div class="tablet:grid-col-4 desktop:grid-col-3 margin-bottom-3 site-c-report-to-congress side-nav">
+    <ul>
       {% assign sections = site.reports_to_congress | where: "report", page.report %}
       {% for section in sections %}
-        <li class="{% if page.url == section.url %} active{% endif %}{% if section.sub %} sub{% endif %}">
+      <li class="{% if page.url == section.url %} active{% endif %}{% if section.sub %} sub{% endif %}">
           <a href="{{ site.baseurl }}{{ section.url }}">{% if section.short %}{{ section.short }}{% else %}{{ section.title }}{% endif %}</a>
-        </li>
+      </li>
       {% endfor %}
         <li class="pdf"><a href="{{ site.baseurl }}/resources/USDS-{{ page.report | replace: " ", "-" }}-Report-to-Congress.pdf">Download the<br/>full report (PDF)</a></li>
-      </ul>
+    </ul>
 
-      <h4>Reports to Congress</h4>
-      <ul>
-        {% assign reports = site.reports_to_congress | where: "front", true | reverse %}
-        {% for report in reports %}
-        <li>
-          <a href="{{ site.baseurl }}{{ report.url }}">{{ report.report_title }}</a>
-        </li>
-        {% endfor %}
-      </ul>
-    </div>
+    <h4>Reports to Congress</h4>
+    <ul>
+      {% assign reports = site.reports_to_congress | where: "front", true | reverse %}
+      {% for report in reports %}
+      <li>
+        <a href="{{ site.baseurl }}{{ report.url }}">{{ report.report_title }}</a>
+      </li>
+      {% endfor %}
+    </ul>
   </div>
+</div>
 </div>


### PR DESCRIPTION
if there's a "impact_statement", then render it at the end of the report-to-congress template.

In the top part of markdown:
```
# Impact statement (Edit this)
impact_statement:
```

Result:
---
![Image](https://github.com/usds/website/assets/74203452/5c73fc57-24b3-4d6b-8bd7-ae62cf812267)


Notes:
 - If no `impact_statement` header, then renders EXACTLY like it does current.
 - Will be "two column layout" unless on mobile, then folds into a single column.
 