### PR TITLE
Downgrade to previous Ubuntu version, which is LTS

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,7 +37,7 @@ concurrency:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - name: Retrieve commit history
         uses: actions/checkout@v3
@@ -77,7 +77,7 @@ jobs:
         uses: actions/upload-pages-artifact@v1
 
   deploy:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: build
     environment:
       name: github-pages


### PR DESCRIPTION
Recently, ubuntu-latest was updated to 24.04. This doesn't work with the version of setup-ruby that we use. Rather than debug that, downgrade to the previous version of Ubuntu which is LTS and supported for 2 years according to this doc: https://github.com/actions/runner-images/issues/10636.

setup-ruby should probably be updated at some point soon because our pinned version is 2+ years old.