### PR TITLE
Upgrade upload-pages-artifact to v3

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -74,7 +74,7 @@ jobs:
         run: echo ${{ inputs.ref }} > ./_site/ref.txt; grep .*[^\s\n\r].* ./_site/ref.txt || echo $GITHUB_REF > ./_site/ref.txt
 
       - name: Store newly built files as artifact of workflow run
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
 
   deploy:
     runs-on: ubuntu-22.04


### PR DESCRIPTION
upload-pages-artifact v1 uses a version of upload-artifact which is no longer supported.

See this `build` error: https://github.com/usds/website/actions/runs/13118432025/job/36598375888

Attempt to bump to the latest. Unfortunately the stage deploy doesn't use this action/lib, so this cannot be tested there first.

I don't believe we're affected by any of the documented breaking changes across the version bumps to get to latest, but I can't say for sure.