### PR TITLE
Fix deploy workflow to compile CSS with Dart Sass

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -56,6 +56,18 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
           cache-version: 1 # Increment this number if you need to re-download cached gems
 
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+          cache: 'npm'
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build CSS with Dart Sass
+        run: npm run css
+
       - name: Setup Pages
         id: pages
         uses: actions/configure-pages@v2


### PR DESCRIPTION
## Summary
- Add Node.js setup and npm build step to deploy workflow
- Fixes social icons appearing black instead of white in footer

## Problem
The deploy workflow was only running `bundle exec jekyll build`, which uses Jekyll's built-in Ruby Sass. Ruby Sass doesn't support the `@forward` syntax used in our SCSS files, so the footer social link styles were silently dropped.

## Solution
Run `npm run css` before Jekyll build to compile SCSS with Dart Sass (which supports `@forward`).

## Test plan
- [ ] Merge this PR
- [ ] Trigger a deploy (manual workflow run)
- [ ] Verify social icons in footer are white on usds.gov